### PR TITLE
DNS Dumpster fault tolerance

### DIFF
--- a/pdlist/source/dnsdumpster.py
+++ b/pdlist/source/dnsdumpster.py
@@ -29,6 +29,7 @@ def parse(domains):
     subdomains = []
     for domain in domains:
         results = DNSDumpsterAPI().search(domain)
+        if not results: continue
         subdomains += list(set(find('domain', results['dns_records'])))
         subdomains += list(set(find('reverse_dns', results['dns_records'])))
     return subdomains

--- a/pdlist/source/dnsdumpster.py
+++ b/pdlist/source/dnsdumpster.py
@@ -29,7 +29,8 @@ def parse(domains):
     subdomains = []
     for domain in domains:
         results = DNSDumpsterAPI().search(domain)
-        if not results: continue
+        if not results:
+            continue
         subdomains += list(set(find('domain', results['dns_records'])))
         subdomains += list(set(find('reverse_dns', results['dns_records'])))
     return subdomains


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
DNSDumpsterAPI returns an empty list when there is an error with the query.  
This small fix ignores empty results and moves on to the next query.

Does this close any currently open issues?
------------------------------------------
\-

Any relevant logs, error output, etc?
-------------------------------------
\-

Any other comments?
-------------------
\-

Where has this been tested?
---------------------------

**Operating System:** Ubuntu 18

**Platform:** Python 3.6.8

**Target Platform:** ?
