### PR TITLE
Sort domains before display

### DIFF
--- a/pdlist/main.py
+++ b/pdlist/main.py
@@ -19,7 +19,8 @@ import pdlist.source.certspotter as cs
 import pdlist.source.hackertarget as ht
 from pdlist.utils import (polish_subdomain_strings,
                           remove_unrelated_domains,
-                          clean_domain_strings)
+                          clean_domain_strings,
+                          sort_domains)
 
 
 __all__ = ('main',)
@@ -104,6 +105,9 @@ def main():
         subdomains = remove_unrelated_domains(subdomains, domains)
 
     subdomains = list(set([x for x in subdomains if x]))
+
+    subdomains = sort_domains(subdomains)
+
     print()
     print()
 

--- a/pdlist/utils.py
+++ b/pdlist/utils.py
@@ -11,6 +11,7 @@ utils functions for pdlist
 :License: BSD (see /LICENSE).
 """
 import re
+from collections import defaultdict
 
 
 def remove_unrelated_domains(subdomains, domains):
@@ -93,4 +94,23 @@ def clean_domain_strings(domains):
     """
     domains = [item.rstrip('/') for item in domains]
     domains = [re.sub(r'(http://|https://)', '', item) for item in domains]
+    return domains
+
+
+def sort_domains(domains):
+    """
+    This function is used to sort the domains in a hierarchical order for
+    readability.
+
+    Args:
+    domains -- the list of input domains
+
+    Returns:
+    domains -- hierarchically sorted list of domains
+    """
+    domainbits = [domain.lower().split('.') for domain in domains]
+    for domain in domainbits:
+        domain.reverse()
+    sorted(domainbits)
+    domains = [('.'.join(reversed(domain))) for domain in sorted(domainbits)]
     return domains


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Domains are sorted in a hierarchically before displaying. This helps with readability.
eg:
```
test.google.com
google.com
www.google.com
test2.test.google.com
```
becomes
```
google.com
test.google.com
test2.test.google.com
www.google.com
```

Does this close any currently open issues?
------------------------------------------
-

Any relevant logs, error output, etc?
-------------------------------------
-

Any other comments?
-------------------
-

Where has this been tested?
---------------------------

**Operating System:** Mac OSX 10.14.6

**Platform:** Python 3.6.5

**Target Platform:** -
