### PR TITLE
Fix link for example.com in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ using pyenv as I am doing you should probably substitute `pip` with `pip3` and
 ## USAGE
 
 To have a list of subdomains passively of for example
-[example.com](example.com) we can do:
+[example.com](https://example.com/) we can do:
 
 ```sh
 pdlist example.com


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Previously github thinks that it's a file name, which leads to linking to 404 github webpage, so with the change it links to the example.com website